### PR TITLE
Fix crash when toggling dark mode

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -21,7 +21,9 @@ function setupPage() {
     element.classList.toggle('dark-mode') 
     const particles = document.querySelector('#particles-js')
     // particles.classList.toggle('.particles-js-white')
-    particles.parentNode.removeChild(particles)
+    if (particles && particles.parentNode) {
+      particles.parentNode.removeChild(particles)
+    }
 
   
   }


### PR DESCRIPTION
## Summary
- prevent runtime error if `particles-js` is missing

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d1ee773c8832d8ff204103a0b7028