### PR TITLE
Add Jest setup and dark mode test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # dromerosalem.github.io
+
+## Running tests
+
+Install dependencies (if needed) and run:
+
+```bash
+npm test
+```

--- a/js/__tests__/main.test.js
+++ b/js/__tests__/main.test.js
@@ -1,0 +1,37 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+
+describe('myFunction', () => {
+  let window, document, myFunction;
+
+  beforeEach(() => {
+    const html = `<!DOCTYPE html><html><body><input class="onoffswitch-checkbox" /></body></html>`;
+    window = new JSDOM(html).window;
+    document = window.document;
+    // Expose globals expected by main.js
+    global.window = window;
+    global.document = document;
+    global.AOS = { init: jest.fn() };
+    global.particlesJS = jest.fn();
+    global.$ = jest.fn(() => ({ slick: jest.fn() }));
+    // Load script
+    const scriptContent = fs.readFileSync(require.resolve('../main.js'), 'utf8');
+    const scriptModule = { exports: {} };
+    const func = new Function('module', 'exports', 'require', 'window', 'document', scriptContent);
+    func(scriptModule, scriptModule.exports, require, window, document);
+    myFunction = scriptModule.exports.myFunction;
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.AOS;
+    delete global.particlesJS;
+    delete global.$;
+  });
+
+  test('toggles dark-mode and does not throw when #particles-js missing', () => {
+    expect(() => myFunction()).not.toThrow();
+    expect(document.body.classList.contains('dark-mode')).toBe(true);
+  });
+});

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,18 @@
 
 
+function myFunction() {
+  document.querySelectorAll('.anchorFooter').forEach(element => {
+    element.classList.toggle('dark-mode')
+  })
+  const element = document.body
+  element.classList.toggle('dark-mode')
+  const particles = document.querySelector('#particles-js')
+  // particles.classList.toggle('.particles-js-white')
+  if (particles && particles.parentNode) {
+    particles.parentNode.removeChild(particles)
+  }
+}
+
 function setupPage() {
 
   $(function(){
@@ -9,24 +22,8 @@ function setupPage() {
       autoplay: true,
       autoplaySpeed: 2000
     })
-      
+
   })
-
-
-  function myFunction() {
-    document.querySelectorAll('.anchorFooter').forEach(element => {
-      element.classList.toggle('dark-mode')
-    })
-    const element = document.body
-    element.classList.toggle('dark-mode') 
-    const particles = document.querySelector('#particles-js')
-    // particles.classList.toggle('.particles-js-white')
-    if (particles && particles.parentNode) {
-      particles.parentNode.removeChild(particles)
-    }
-
-  
-  }
   
   const onoffswitch = document.querySelector('.onoffswitch-checkbox')
 
@@ -38,8 +35,12 @@ function setupPage() {
   particlesJS("particles-js", 
   {"particles":{"number":{"value":160,"density":{"enable":true,"value_area":800}},"color":{"value":"#ffffff"},"shape":{"type":"circle","stroke":{"width":0,"color":"#000000"},"polygon":{"nb_sides":5},"image":{"src":"img/github.svg","width":100,"height":100}},"opacity":{"value":1,"random":true,"anim":{"enable":true,"speed":1,"opacity_min":0,"sync":false}},"size":{"value":3,"random":true,"anim":{"enable":false,"speed":4,"size_min":0.3,"sync":false}},"line_linked":{"enable":false,"distance":150,"color":"#ffffff","opacity":0.4,"width":1},"move":{"enable":true,"speed":1,"direction":"none","random":true,"straight":false,"out_mode":"out","bounce":false,"attract":{"enable":false,"rotateX":600,"rotateY":600}}},"interactivity":{"detect_on":"canvas","events":{"onhover":{"enable":true,"mode":"bubble"},"onclick":{"enable":true,"mode":"repulse"},"resize":true},"modes":{"grab":{"distance":400,"line_linked":{"opacity":1}},"bubble":{"distance":250,"size":0,"duration":2,"opacity":0,"speed":3},"repulse":{"distance":400,"duration":0.4},"push":{"particles_nb":4},"remove":{"particles_nb":2}}},"retina_detect":true});
   
-  AOS.init()
+AOS.init()
 
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { myFunction, setupPage }
 }
 
 window.addEventListener('DOMContentLoaded', setupPage)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dromerosalem.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.6.2"
+  },
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- add new package.json with jest dev dependency and test script
- export `myFunction` and `setupPage` to make them testable
- create `js/__tests__/main.test.js` covering `myFunction`
- ignore `node_modules`
- document test command in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d259b5efc832d83da89ee8848675c