### PR TITLE
Fix heading typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
       </article>
       <hr>
       <article>
-        <h3>Software Engeenering Immersive</h3>
+        <h3>Software Engineering Immersive</h3>
         <h2>GENERAL ASSEMBLY</h2>
         <p>London, UK</p>
       </article>


### PR DESCRIPTION
## Summary
- correct the heading "Software Engeenering Immersive" to "Software Engineering Immersive" in `index.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d2585cd40832db9646ac61905b19c